### PR TITLE
Use ServiceWorkerGlobalScope as fallback for Window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,7 +340,9 @@ once_cell = { version = "1.5.2", default-features = false, features=["std"], opt
 once_cell = { version = "1.5.2", default-features = false, features=["std"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
-web-sys = { version = "0.3.37", default-features = false, features = ["Crypto", "Window"] }
+web-sys = { version = "0.3.51", default-features = false, features = ["Crypto", "Window", "ServiceWorkerGlobalScope"] }
+wasm-bindgen = { version = "0.2.80" }
+js-sys = { version = "0.3.51" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.8", default-features = false, features = ["ntsecapi", "wtypesbase"] }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -236,6 +236,20 @@ mod sysrand_chunk {
 ))]
 mod sysrand_chunk {
     use crate::error;
+    use js_sys::Reflect;
+    use wasm_bindgen::{JsValue, JsCast};
+    use web_sys::Crypto;
+
+    /**
+     * Gets a handle to Crypto in both normal and worker environments. Based on
+     * the discussion in https://github.com/rustwasm/wasm-bindgen/issues/2148
+     * and the approach taken here: https://github.com/devashishdxt/rexie/commit/8637e4ebc2d2dfc6b33cd60dc85b99e46d6afa96
+     */
+    fn get_crypto() -> Result<Crypto, error::Unspecified> {
+        Reflect::get(&js_sys::global(), &JsValue::from("crypto"))
+            .map_err(|_| error::Unspecified)?
+            .dyn_into::<Crypto>().map_err(|_| error::Unspecified)
+    }
 
     pub fn chunk(mut dest: &mut [u8]) -> Result<usize, error::Unspecified> {
         // This limit is specified in
@@ -245,10 +259,9 @@ mod sysrand_chunk {
             dest = &mut dest[..MAX_LEN];
         };
 
-        let _ = web_sys::window()
-            .ok_or(error::Unspecified)?
-            .crypto()
-            .map_err(|_| error::Unspecified)?
+        let crypto = get_crypto()?;
+
+        let _ = crypto
             .get_random_values_with_u8_array(dest)
             .map_err(|_| error::Unspecified)?;
 


### PR DESCRIPTION
Cherry-pick of https://github.com/oliverdunk/ring/commit/d92ad9cb363cca8d3372d75a02ae3fc77a2694a2

CC: @oliverdunk 