### PR TITLE
[0.17] Enable building and running on Windows ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,9 @@ jobs:
           toolchain: stable
           profile: minimal
 
+      - run: echo "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" >> $GITHUB_PATH
+        shell: bash
+
       - run: sh mk/package.sh
         shell: bash
 
@@ -167,6 +170,7 @@ jobs:
           - aarch64-apple-ios
           - aarch64-apple-darwin
           - aarch64-linux-android
+          - aarch64-pc-windows-msvc
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
           - arm-unknown-linux-gnueabihf
@@ -205,6 +209,11 @@ jobs:
           - target: aarch64-linux-android
             host_os: ubuntu-18.04
             # TODO: https://github.com/briansmith/ring/issues/486
+            cargo_options: --no-run
+
+          - target: aarch64-pc-windows-msvc
+            host_os: windows-latest
+            # GitHub Actions doesn't have a way to run this target yet.
             cargo_options: --no-run
 
           - target: aarch64-unknown-linux-gnu
@@ -275,6 +284,12 @@ jobs:
         run: |
           sudo xcode-select -s /Applications/Xcode_12.4.app &&
           sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+
+      - if: ${{ matrix.target == 'aarch64-pc-windows-msvc' }}
+        run: |
+          echo "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" >> $GITHUB_PATH
+          echo "RUSTFLAGS=-C target-feature=+crt-static" >> $GITHUB_ENV
+        shell: bash
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -33,9 +33,12 @@ apply when building from crates.io:
   primitives (32- and 64- bit Intel, and 32- and 64-bit ARM), Perl must be
   installed and in `$PATH`.
 
-* For Windows targets, `target/tools/windows/nasm/nasm[.exe]` is used as the
-  assembler. The version to use and how to download it is documented in
-  [.github/workflows/ci.yml](.github/workflows/ci.yml).
+* For Windows targets except ARM64, `target/tools/windows/nasm/nasm[.exe]`
+  is used as the assembler. The version to use and how to download it is
+  documented in [.github/workflows/ci.yml](.github/workflows/ci.yml).
+
+* For Windows ARM64 target, Clang is used as the C compiler and the assembler.
+  See below "Building for Windows ARM64" section.
 
 Cross Compiling
 ---------------
@@ -57,10 +60,12 @@ that the current beta and nightly releases work.
 
 On Windows, *ring* supports the x86_64-pc-windows-msvc and i686-pc-windows-msvc
 targets best. These targets require the “Visual C++ Build Tools
-2015” package or Visual Studio 2015 Update 3 or later to be installed. Patches
-to get it working on other variants, including in particular Visual Studio 2017
-([#338]), Windows ARM platforms, Windows Universal Platform, Windows XP (the
-v140_xp toolchain; [#339]), and the -gnu targets ([#330]) are welcome.
+2015” package or Visual Studio 2015 Update 3 or later to be installed.
+*ring* now also supports the aarch64-pc-windows-msvc target. For the detailed
+instructions please see the next section.
+Patches to get it working on other variants, including in particular Visual Studio 2017
+([#338]), Windows Universal Platform, Windows XP (the v140_xp toolchain; [#339]),
+and the -gnu targets ([#330]) are welcome.
 
 For other platforms, GCC 4.6 or later and Clang 3.5 or later are currently
 supported best. The build script passes options to the C/C++ compiler that are
@@ -76,6 +81,34 @@ the wrapper automatically passes flags to the actual compiler to define the
 `__ANDROID_API__` macro. Otherwise, the macro `__ANDROID_API__` must be
 defined with a value of at least 21 on 64-bit targets or 18 on 32-bit targets;
 e.g. export `CFLAGS=-D__ANDROID_API__=21`.
+
+
+Building for Windows ARM64
+--------------------------
+
+Windows ARM64 target requires the “Visual C++ Build Tools 2019” package or
+Visual Studio 2019 or later to be installed. “Desktop development with C++”
+workflow should be installed, as well as
+“MSVC v142 - VS 2019 C++ ARM64 build tools” component.
+
+To build *ring* for Windows ARM64, you will need to install Clang as it is used
+as the C compiler and the assembler for that platform. You can either use
+the version of Clang installed by Visual Studio, a standalone version from
+llvm.org, or a mingw64 version of Clang, for example, from [llvm-mingw
+project](https://github.com/mstorsjo/llvm-mingw).
+
+If you're buiding *ring* on an ARM64 device like Surface Pro X, please note
+that llvm.org and llvm-mingw have native ARM64 versions of Clang available.
+Also, if you're building *ring* on an ARM64 device, you might want to use
+`aarch64-pc-windows-msvc` Rustup toolchain, which can be installed using
+`rustup toolchain add aarch64-pc-windows-msvc`.
+
+When building on an ARM64 device, due to a bug in the Visual Studio installer,
+if you're using `rustc` version < 1.55 you would need to run `cargo build` /
+`cargo test` commands from x86_arm64 Developer Command Prompt. You can use
+`C:\Program Files (x86)\Microsoft Visual Studio\2019\<edition>\VC\Auxiliary\Build\vcvarsx86_arm64.bat`
+batch script to configure the environment. If you use `rustc` 1.55 beta or newer,
+you can run `cargo` commands without configuring the dev environment beforehand.
 
 
 Additional Features that are Useful for Development

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,8 +329,8 @@ name = "ring"
 [dependencies]
 untrusted = { version = "0.7.1" }
 
-[target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux"))))'.dependencies]
-spin = { version = "0.5.2", default-features = false }
+[target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
+spin = { version = "0.9.2", default-features = false, features = ["once"] }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.84", default-features = false }
@@ -345,7 +345,7 @@ wasm-bindgen = { version = "0.2.80" }
 js-sys = { version = "0.3.51" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.8", default-features = false, features = ["ntsecapi", "wtypesbase"] }
+winapi = { version = "0.3.9", default-features = false, features = ["ntsecapi", "wtypesbase", "processthreadsapi"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.18", default-features = false }

--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -15,6 +15,7 @@
 #include <ring-core/cpu.h>
 #include "internal.h"
 
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 // Our assembly does not use the GOT to reference symbols, which means
 // references to visible symbols will often require a TEXTREL. This is
 // undesirable, so all assembly-referenced symbols should be hidden. CPU
@@ -26,7 +27,6 @@
 #define HIDDEN __attribute__((visibility("hidden")))
 #endif
 
-#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 // This value must be explicitly initialised to zero in order to work around a
 // bug in libtool or the linker on OS X.
 //

--- a/crypto/fipsmodule/ec/ecp_nistz384.inl
+++ b/crypto/fipsmodule/ec/ecp_nistz384.inl
@@ -252,6 +252,6 @@ void nistz384_point_mul(P384_POINT *r, const BN_ULONG p_scalar[P384_LIMBS],
   add_precomputed_w5(r, wvalue, table);
 }
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -31,7 +31,12 @@ pub(crate) fn features() -> Features {
         target_arch = "x86_64",
         all(
             any(target_arch = "aarch64", target_arch = "arm"),
-            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+            any(
+                target_os = "android",
+                target_os = "fuchsia",
+                target_os = "linux",
+                target_os = "windows"
+            )
         )
     ))]
     {
@@ -49,7 +54,12 @@ pub(crate) fn features() -> Features {
 
             #[cfg(all(
                 any(target_arch = "aarch64", target_arch = "arm"),
-                any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+                any(
+                    target_os = "android",
+                    target_os = "fuchsia",
+                    target_os = "linux",
+                    target_os = "windows"
+                )
             ))]
             {
                 arm::setup();
@@ -162,6 +172,27 @@ pub(crate) mod arm {
         }
     }
 
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    pub fn setup() {
+        // We do not need to check for the presence of NEON, as Armv8-A always has it
+        let mut features = NEON.mask;
+
+        let result = unsafe {
+            winapi::um::processthreadsapi::IsProcessorFeaturePresent(
+                winapi::um::winnt::PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE,
+            )
+        };
+
+        if result != 0 {
+            // These are all covered by one call in Windows
+            features |= AES.mask;
+            features |= PMULL.mask;
+            features |= SHA256.mask;
+        }
+
+        unsafe { OPENSSL_armcap_P = features };
+    }
+
     macro_rules! features {
         {
             $(
@@ -237,7 +268,12 @@ pub(crate) mod arm {
             }
 
             #[cfg(all(
-                any(target_os = "android", target_os = "fuchsia", target_os = "linux"),
+                any(
+                    target_os = "android",
+                    target_os = "fuchsia",
+                    target_os = "linux",
+                    target_os = "windows"
+                ),
                 any(target_arch = "arm", target_arch = "aarch64")
             ))]
             {


### PR DESCRIPTION
Cherry-pick and backport of e8e9a67a1f82e81e6c3b7fb5b5ee7cf786d31726

**Note**: These use `clang` instead of `MSVC` to build on Windows ARM64. This was necessary at the time of the original commit, but MSVC _may_ have added support since.

---

`build.rs` has diverged signficantly from `0.17.0-alpha.11` to when this commit was merged. Since a merge was not possible, I rewrote the required changes from scratch.

This can be tested with https://github.com/1Password/ring/tree/kv/windows-arm-release.