### PR TITLE
Raise version to 0.9999

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "doc/link-to-readme.md"
 repository = "https://github.com/briansmith/ring"
 
 # Keep in sync with `links` below.
-version = "0.17.0-alpha.11"
+version = "0.9999.0-1p-fork"
 
 # Keep in sync with `version` above.
 #
@@ -21,7 +21,7 @@ version = "0.17.0-alpha.11"
 # build.rs uses this to derive the prefix for FFI symbols and the file names
 # of the FFI libraries, so it must be a valid identifier prefix and a valid
 # filename prefix.
-links = "ring_core_0_17_0_alpha_11"
+links = "ring_core_0_9999_0_1p_fork"
 
 include = [
     "LICENSE",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,3 @@
 [toolchain]
-# Cargo 0.60 pretty prints the `Cargo.toml` and causes additional deltas when releasing
-channel = "1.59.0"
+channel = "1.84.0"
 components = ["clippy", "rustfmt"]

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -447,8 +447,8 @@ union State {
 #[derive(Clone, Copy)]
 #[repr(C)]
 union Output {
-    as64: [BigEndian<u64>; 512 / 8 / core::mem::size_of::<BigEndian<u64>>()],
-    as32: [BigEndian<u32>; 256 / 8 / core::mem::size_of::<BigEndian<u32>>()],
+    as64: [BigEndian<u64>; 512 / 8 / size_of::<BigEndian<u64>>()],
+    as32: [BigEndian<u32>; 256 / 8 / size_of::<BigEndian<u32>>()],
 }
 
 /// The maximum block length (`Algorithm::block_len`) of all the algorithms in

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -54,11 +54,11 @@ macro_rules! define_endian {
 
 macro_rules! impl_from_byte_array {
     ($endian:ident, $base:ident, $elems:expr) => {
-        impl FromByteArray<[u8; $elems * core::mem::size_of::<$base>()]>
+        impl FromByteArray<[u8; $elems * size_of::<$base>()]>
             for [$endian<$base>; $elems]
         {
             #[inline]
-            fn from_byte_array(a: &[u8; $elems * core::mem::size_of::<$base>()]) -> Self {
+            fn from_byte_array(a: &[u8; $elems * size_of::<$base>()]) -> Self {
                 unsafe { core::mem::transmute_copy(a) }
             }
         }
@@ -67,13 +67,13 @@ macro_rules! impl_from_byte_array {
 
 macro_rules! impl_array_encoding {
     ($endian:ident, $base:ident, $elems:expr) => {
-        impl ArrayEncoding<[u8; $elems * core::mem::size_of::<$base>()]>
+        impl ArrayEncoding<[u8; $elems * size_of::<$base>()]>
             for [$endian<$base>; $elems]
         {
             #[inline]
-            fn as_byte_array(&self) -> &[u8; $elems * core::mem::size_of::<$base>()] {
+            fn as_byte_array(&self) -> &[u8; $elems * size_of::<$base>()] {
                 let as_bytes_ptr =
-                    self.as_ptr() as *const [u8; $elems * core::mem::size_of::<$base>()];
+                    self.as_ptr() as *const [u8; $elems * size_of::<$base>()];
                 unsafe { &*as_bytes_ptr }
             }
         }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -101,8 +101,8 @@ pub(crate) mod sealed {
 }
 
 /// A type that can be returned by `ring::rand::generate()`.
-pub trait RandomlyConstructable: self::sealed::RandomlyConstructable {}
-impl<T> RandomlyConstructable for T where T: self::sealed::RandomlyConstructable {}
+pub trait RandomlyConstructable: sealed::RandomlyConstructable {}
+impl<T> RandomlyConstructable for T where T: sealed::RandomlyConstructable {}
 
 /// A secure random number generator where the random values come directly
 /// from the operating system.
@@ -277,7 +277,7 @@ mod sysrand_chunk {
     pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
         use winapi::shared::wtypesbase::ULONG;
 
-        assert!(core::mem::size_of::<usize>() >= core::mem::size_of::<ULONG>());
+        assert!(size_of::<usize>() >= size_of::<ULONG>());
         let len = core::cmp::min(dest.len(), polyfill::usize_from_u32(ULONG::max_value()));
         let result = unsafe {
             winapi::um::ntsecapi::RtlGenRandom(

--- a/src/rsa/keypair/core.rs
+++ b/src/rsa/keypair/core.rs
@@ -173,7 +173,7 @@ impl RsaKeyPair {
         // length of half_n_bits + 1, this check gives us 2**half_n_bits <= d,
         // and knowing d is odd makes the inequality strict.
         let (d, d_bits) = bigint::Nonnegative::from_be_bytes_with_bit_length(d)
-            .map_err(|_| error::KeyRejected::invalid_encoding())?;
+            .map_err(|_| KeyRejected::invalid_encoding())?;
         if !(half_n_bits < d_bits) {
             return Err(KeyRejected::inconsistent_components());
         }
@@ -300,7 +300,7 @@ impl<M: Prime + Clone> PrivatePrime<M> {
     fn new(p: bigint::Nonnegative, dP: untrusted::Input) -> Result<Self, KeyRejected> {
         let (p, p_bits) = bigint::Modulus::from_nonnegative_with_bit_length(p)?;
         if p_bits.as_usize_bits() % 512 != 0 {
-            return Err(error::KeyRejected::private_modulus_len_not_multiple_of_512_bits());
+            return Err(KeyRejected::private_modulus_len_not_multiple_of_512_bits());
         }
 
         // [NIST SP-800-56B rev. 1] 6.4.1.4.3 - Steps 7.a & 7.b.

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -52,7 +52,7 @@ macro_rules! rsa_params {
 rsa_params!(
     RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,
     1024,
-    &super::padding::RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY,
+    &padding::RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY,
     "Verification of signatures using RSA keys of 1024-8192 bits,
              PKCS#1.5 padding, and SHA-1.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -60,7 +60,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_2048_8192_SHA1_FOR_LEGACY_USE_ONLY,
     2048,
-    &super::padding::RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY,
+    &padding::RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PKCS#1.5 padding, and SHA-1.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -68,7 +68,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY,
     1024,
-    &super::padding::RSA_PKCS1_SHA256,
+    &padding::RSA_PKCS1_SHA256,
     "Verification of signatures using RSA keys of 1024-8192 bits,
              PKCS#1.5 padding, and SHA-256.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -76,7 +76,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_2048_8192_SHA256,
     2048,
-    &super::padding::RSA_PKCS1_SHA256,
+    &padding::RSA_PKCS1_SHA256,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PKCS#1.5 padding, and SHA-256.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -84,7 +84,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_2048_8192_SHA384,
     2048,
-    &super::padding::RSA_PKCS1_SHA384,
+    &padding::RSA_PKCS1_SHA384,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PKCS#1.5 padding, and SHA-384.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -92,7 +92,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_2048_8192_SHA512,
     2048,
-    &super::padding::RSA_PKCS1_SHA512,
+    &padding::RSA_PKCS1_SHA512,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PKCS#1.5 padding, and SHA-512.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -100,7 +100,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_1024_8192_SHA512_FOR_LEGACY_USE_ONLY,
     1024,
-    &super::padding::RSA_PKCS1_SHA512,
+    &padding::RSA_PKCS1_SHA512,
     "Verification of signatures using RSA keys of 1024-8192 bits,
              PKCS#1.5 padding, and SHA-512.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -108,7 +108,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_3072_8192_SHA384,
     3072,
-    &super::padding::RSA_PKCS1_SHA384,
+    &padding::RSA_PKCS1_SHA384,
     "Verification of signatures using RSA keys of 3072-8192 bits,
              PKCS#1.5 padding, and SHA-384.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -117,7 +117,7 @@ rsa_params!(
 rsa_params!(
     RSA_PSS_2048_8192_SHA256,
     2048,
-    &super::padding::RSA_PSS_SHA256,
+    &padding::RSA_PSS_SHA256,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PSS padding, and SHA-256.\n\nSee \"`RSA_PSS_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -125,7 +125,7 @@ rsa_params!(
 rsa_params!(
     RSA_PSS_2048_8192_SHA384,
     2048,
-    &super::padding::RSA_PSS_SHA384,
+    &padding::RSA_PSS_SHA384,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PSS padding, and SHA-384.\n\nSee \"`RSA_PSS_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -133,7 +133,7 @@ rsa_params!(
 rsa_params!(
     RSA_PSS_2048_8192_SHA512,
     2048,
-    &super::padding::RSA_PSS_SHA512,
+    &padding::RSA_PSS_SHA512,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PSS padding, and SHA-512.\n\nSee \"`RSA_PSS_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -172,7 +172,7 @@ where
         message: &[u8],
         signature: &[u8],
     ) -> Result<(), error::Unspecified> {
-        let key = super::public::Key::try_from_components(self, params)?;
+        let key = public::Key::try_from_components(self, params)?;
         key.verify(
             params.padding_alg,
             untrusted::Input::from(message),


### PR DESCRIPTION
This achieves the goal of keeping this fork out of conflict with public crates that use _ring_ 0.17 during dependency resolution.

As a result, we (1Password) can move our third-party dependencies that depend on _ring_ 0.17 to newer versions instead of having to hold them back due to versioning conflicts. The chosen number `0.9999` has no significance beyond being high enough that its statistically unlikely to ever appear for real on crates.io.

Additionally, I added a semver specifier to make it clear this is not intended for public use. 1Password is only using this for technical debt reasons and we hope to remove the need.