### PR TITLE
Backport mainstream ring's rand.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,9 +344,6 @@ web-sys = { version = "0.3.51", default-features = false, features = ["Crypto", 
 wasm-bindgen = { version = "0.2.80" }
 js-sys = { version = "0.3.51" }
 
-[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "wasi", target_env = "p1"))'.dependencies]
-getrandom = "0.3"
-
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", default-features = false, features = ["ntsecapi", "wtypesbase", "processthreadsapi"] }
 
@@ -369,7 +366,7 @@ slow_tests = []
 std = ["alloc"]
 test_logging = []
 wasm32_c = []
-andi = []
+custom_rand = []
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,6 +362,7 @@ cc = { version = "1.0.66", default-features = false }
 default = ["alloc", "dev_urandom_fallback"]
 alloc = []
 dev_urandom_fallback = ["once_cell"]
+less-safe-getrandom-custom-wasm-hostruntime = []
 internal_benches = []
 slow_tests = []
 std = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ name = "ring"
 
 [dependencies]
 untrusted = { version = "0.7.1" }
-getrandom = { version = "0.3", default-features = false, optional = true }
+getrandom = { version = "0.2.10" }
 
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 spin = { version = "0.9.2", default-features = false, features = ["once"] }
@@ -367,7 +367,7 @@ slow_tests = []
 std = ["alloc"]
 test_logging = []
 wasm32_c = []
-getrandom = ["dep:getrandom"]
+wasm32_unknown_unknown_js = ["getrandom/js"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,6 +344,9 @@ web-sys = { version = "0.3.51", default-features = false, features = ["Crypto", 
 wasm-bindgen = { version = "0.2.80" }
 js-sys = { version = "0.3.51" }
 
+[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "wasi", target_env = "p1"))'.dependencies]
+getrandom = "0.3"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", default-features = false, features = ["ntsecapi", "wtypesbase", "processthreadsapi"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,6 +328,7 @@ name = "ring"
 
 [dependencies]
 untrusted = { version = "0.7.1" }
+getrandom = { version = "0.3", default-features = false, optional = true }
 
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 spin = { version = "0.9.2", default-features = false, features = ["once"] }
@@ -366,7 +367,7 @@ slow_tests = []
 std = ["alloc"]
 test_logging = []
 wasm32_c = []
-custom_rand = []
+getrandom = ["dep:getrandom"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -369,6 +369,7 @@ slow_tests = []
 std = ["alloc"]
 test_logging = []
 wasm32_c = []
+andi = []
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -141,6 +141,7 @@ impl EphemeralPrivateKey {
         self.algorithm
     }
 
+    /// Less safe access to the private key bytes.
     #[cfg(test)]
     pub fn bytes(&self) -> &[u8] {
         self.private_key.bytes_less_safe()

--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -297,7 +297,7 @@ impl core::fmt::Debug for NonceRandom<'_> {
 }
 
 impl rand::sealed::SecureRandom for NonceRandom<'_> {
-    fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
+    fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
         // Use the same digest algorithm that will be used to digest the
         // message. The digest algorithm's output is exactly the right size;
         // this is checked below.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 )]
 // `#[derive(...)]` uses `trivial_numeric_casts` and `unused_qualifications`
 // internally.
-#![deny(missing_docs, variant_size_differences)]
+#![deny(missing_docs, unused_qualifications, variant_size_differences)]
 #![forbid(unused_results)]
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,4 +125,5 @@ mod sealed {
     // impl sealed::Sealed for MyType {}
     // ```
     pub trait Sealed {}
+    pub struct Arg;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 )]
 // `#[derive(...)]` uses `trivial_numeric_casts` and `unused_qualifications`
 // internally.
-#![deny(missing_docs, unused_qualifications, variant_size_differences)]
+#![deny(missing_docs, variant_size_differences)]
 #![forbid(unused_results)]
 #![no_std]
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -124,8 +124,7 @@ impl SystemRandom {
 // system's) CSPRNG. Avoid using it on targets where it uses the `rdrand`
 // implementation.
 #[cfg(any(
-    all(feature = "less-safe-getrandom-custom-or-rdrand", target_os = "none"),
-    all(feature = "less-safe-getrandom-espidf", target_os = "espidf"),
+    feature = "less-safe-getrandom-custom-wasm-hostruntime",
     target_os = "aix",
     target_os = "android",
     target_os = "dragonfly",

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -269,6 +269,21 @@ mod sysrand_chunk {
     }
 }
 
+#[cfg(all(
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "wasi",
+    target_env = "p1",
+))]
+mod sysrand_chunk {
+    use crate::error;
+
+    pub fn chunk(mut dest: &mut [u8]) -> Result<usize, error::Unspecified> {
+        // The getrandom crate is used in the latest version of ring, and has WASI P1 support: https://github.com/briansmith/ring/blob/522afb658067bed0512a49f66bd4c07389b51ab3/src/rand.rs#L168
+        getrandom::getrandom(dest).map_err(|_| error::Unspecified)
+    }
+}
+
 #[cfg(windows)]
 mod sysrand_chunk {
     use crate::{error, polyfill};

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -4,9 +4,9 @@
 // purpose with or without fee is hereby granted, provided that the above
 // copyright notice and this permission notice appear in all copies.
 //
-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 // WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
 // SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 // WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
@@ -14,16 +14,8 @@
 
 //! Cryptographic pseudo-random number generation.
 //!
-//! An application should create a single `SystemRandom` and then use it for
-//! all randomness generation. Functions that generate random bytes should take
-//! a `&dyn SecureRandom` parameter instead of instantiating their own. Besides
-//! being more efficient, this also helps document where non-deterministic
-//! (random) outputs occur. Taking a reference to a `SecureRandom` also helps
-//! with testing techniques like fuzzing, where it is useful to use a
-//! (non-secure) deterministic implementation of `SecureRandom` so that results
-//! can be replayed. Following this pattern also may help with sandboxing
-//! (seccomp filters on Linux in particular). See `SystemRandom`'s
-//! documentation for more details.
+//! *ring* functions that generate random bytes take a `&dyn SecureRandom`
+//! parameter to make it clear which functions are non-deterministic.
 
 use crate::error;
 
@@ -39,7 +31,7 @@ where
 {
     #[inline(always)]
     fn fill(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        self.fill_impl(dest)
+        self.fill_impl(dest, crate::sealed::Arg)
     }
 }
 
@@ -61,10 +53,7 @@ impl<T: RandomlyConstructable> Random<T> {
 #[inline]
 pub fn generate<T: RandomlyConstructable>(
     rng: &dyn SecureRandom,
-) -> Result<Random<T>, error::Unspecified>
-where
-    T: RandomlyConstructable,
-{
+) -> Result<Random<T>, error::Unspecified> {
     let mut r = T::zero();
     rng.fill(r.as_mut_bytes())?;
     Ok(Random(r))
@@ -75,7 +64,11 @@ pub(crate) mod sealed {
 
     pub trait SecureRandom: core::fmt::Debug {
         /// Fills `dest` with random bytes.
-        fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified>;
+        fn fill_impl(
+            &self,
+            dest: &mut [u8],
+            _: crate::sealed::Arg,
+        ) -> Result<(), error::Unspecified>;
     }
 
     pub trait RandomlyConstructable: Sized {
@@ -83,21 +76,17 @@ pub(crate) mod sealed {
         fn as_mut_bytes(&mut self) -> &mut [u8]; // `AsMut<[u8]>::as_mut`
     }
 
-    macro_rules! impl_random_arrays {
-        [ $($len:expr)+ ] => {
-            $(
-                impl RandomlyConstructable for [u8; $len] {
-                    #[inline]
-                    fn zero() -> Self { [0; $len] }
+    impl<const N: usize> RandomlyConstructable for [u8; N] {
+        #[inline]
+        fn zero() -> Self {
+            [0; N]
+        }
 
-                    #[inline]
-                    fn as_mut_bytes(&mut self) -> &mut [u8] { &mut self[..] }
-                }
-            )+
+        #[inline]
+        fn as_mut_bytes(&mut self) -> &mut [u8] {
+            &mut self[..]
         }
     }
-
-    impl_random_arrays![4 8 16 32 48 64 128 256];
 }
 
 /// A type that can be returned by `ring::rand::generate()`.
@@ -107,6 +96,11 @@ impl<T> RandomlyConstructable for T where T: sealed::RandomlyConstructable {}
 /// A secure random number generator where the random values come directly
 /// from the operating system.
 ///
+/// "Directly from the operating system" here presently means "whatever the
+/// `getrandom` crate does" but that may change in the future. That roughly
+/// means calling libc's `getrandom` function or whatever is analogous to that;
+/// see the `getrandom` crate's documentation for more info.
+///
 /// A single `SystemRandom` may be shared across multiple threads safely.
 ///
 /// `new()` is guaranteed to always succeed and to have low latency; it won't
@@ -115,34 +109,6 @@ impl<T> RandomlyConstructable for T where T: sealed::RandomlyConstructable {}
 /// initialization is deferred to it. Therefore, it may be a good idea to call
 /// `fill()` once at a non-latency-sensitive time to minimize latency for
 /// future calls.
-///
-/// On Linux (including Android), `fill()` will use the [`getrandom`] syscall.
-/// If the kernel is too old to support `getrandom` then by default `fill()`
-/// falls back to reading from `/dev/urandom`. This decision is made the first
-/// time `fill` *succeeds*. The fallback to `/dev/urandom` can be disabled by
-/// disabling the `dev_urandom_fallback` default feature; this should be done
-/// whenever the target system is known to support `getrandom`. When
-/// `/dev/urandom` is used, a file handle for `/dev/urandom` won't be opened
-/// until `fill` is called; `SystemRandom::new()` will not open `/dev/urandom`
-/// or do other potentially-high-latency things. The file handle will never be
-/// closed, until the operating system closes it at process shutdown. All
-/// instances of `SystemRandom` will share a single file handle. To properly
-/// implement seccomp filtering when the `dev_urandom_fallback` default feature
-/// is disabled, allow `getrandom` through. When the fallback is enabled, allow
-/// file opening, `getrandom`, and `read` up until the first call to `fill()`
-/// succeeds; after that, allow `getrandom` and `read`.
-///
-/// On macOS and iOS, `fill()` is implemented using `SecRandomCopyBytes`.
-///
-/// On wasm32-unknown-unknown (non-WASI), `fill()` is implemented using
-/// `window.crypto.getRandomValues()`. It must be used in a context where the
-/// global object is a `Window`; i.e. it must not be used in a Worker or a
-/// non-browser context.
-///
-/// On Windows, `fill` is implemented using the platform's API for secure
-/// random number generation.
-///
-/// [`getrandom`]: http://man7.org/linux/man-pages/man2/getrandom.2.html
 #[derive(Clone, Debug)]
 pub struct SystemRandom(());
 
@@ -154,295 +120,51 @@ impl SystemRandom {
     }
 }
 
+// Use the `getrandom` crate whenever it is using the environment's (operating
+// system's) CSPRNG. Avoid using it on targets where it uses the `rdrand`
+// implementation.
+#[cfg(any(
+    all(feature = "less-safe-getrandom-custom-or-rdrand", target_os = "none"),
+    all(feature = "less-safe-getrandom-espidf", target_os = "espidf"),
+    target_os = "aix",
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "haiku",
+    target_os = "hermit",
+    target_os = "hurd",
+    target_os = "horizon",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "vita",
+    target_os = "windows",
+    target_os = "nto",
+    all(
+        target_vendor = "apple",
+        any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "visionos",
+            target_os = "watchos",
+        )
+    ),
+    all(
+        target_arch = "wasm32",
+        any(
+            target_os = "wasi",
+            all(target_os = "unknown", feature = "wasm32_unknown_unknown_js")
+        )
+    ),
+))]
 impl sealed::SecureRandom for SystemRandom {
     #[inline(always)]
-    fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        fill_impl(dest)
-    }
-}
-
-impl crate::sealed::Sealed for SystemRandom {}
-
-#[cfg(all(feature = "getrandom", target_arch = "wasm32"))]
-use self::getrandom::fill as fill_impl;
-#[cfg(all(
-    any(
-        all(
-            any(target_os = "android", target_os = "linux"),
-            not(feature = "dev_urandom_fallback")
-        ),
-        target_arch = "wasm32",
-        windows
-    ),
-    not(feature = "getrandom")
-))]
-use self::sysrand::fill as fill_impl;
-
-#[cfg(all(
-    any(target_os = "android", target_os = "linux"),
-    feature = "dev_urandom_fallback"
-))]
-use self::sysrand_or_urandom::fill as fill_impl;
-
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-))]
-use self::urandom::fill as fill_impl;
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-use self::darwin::fill as fill_impl;
-
-#[cfg(any(target_os = "fuchsia"))]
-use self::fuchsia::fill as fill_impl;
-
-#[cfg(any(target_os = "android", target_os = "linux"))]
-mod sysrand_chunk {
-    use crate::{c, error};
-
-    #[inline]
-    pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        let chunk_len: c::size_t = dest.len();
-        let r = unsafe { libc::syscall(libc::SYS_getrandom, dest.as_mut_ptr(), chunk_len, 0) };
-        if r < 0 {
-            let errno;
-
-            #[cfg(target_os = "linux")]
-            {
-                errno = unsafe { *libc::__errno_location() };
-            }
-
-            #[cfg(target_os = "android")]
-            {
-                errno = unsafe { *libc::__errno() };
-            }
-
-            if errno == libc::EINTR {
-                // If an interrupt occurs while getrandom() is blocking to wait
-                // for the entropy pool, then EINTR is returned. Returning 0
-                // will cause the caller to try again.
-                return Ok(0);
-            }
-            return Err(error::Unspecified);
-        }
-        Ok(r as usize)
-    }
-}
-
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown",
-    target_env = "",
-))]
-mod sysrand_chunk {
-    use crate::error;
-    use js_sys::Reflect;
-    use wasm_bindgen::{JsCast, JsValue};
-    use web_sys::Crypto;
-
-    /**
-     * Gets a handle to Crypto in both normal and worker environments. Based on
-     * the discussion in https://github.com/rustwasm/wasm-bindgen/issues/2148
-     * and the approach taken here: https://github.com/devashishdxt/rexie/commit/8637e4ebc2d2dfc6b33cd60dc85b99e46d6afa96
-     */
-    fn get_crypto() -> Result<Crypto, error::Unspecified> {
-        Reflect::get(&js_sys::global(), &JsValue::from("crypto"))
-            .map_err(|_| error::Unspecified)?
-            .dyn_into::<Crypto>()
-            .map_err(|_| error::Unspecified)
-    }
-
-    pub fn chunk(mut dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        // This limit is specified in
-        // https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues.
-        const MAX_LEN: usize = 65_536;
-        if dest.len() > MAX_LEN {
-            dest = &mut dest[..MAX_LEN];
-        };
-
-        let crypto = get_crypto()?;
-
-        let _ = crypto
-            .get_random_values_with_u8_array(dest)
-            .map_err(|_| error::Unspecified)?;
-
-        Ok(dest.len())
-    }
-}
-
-#[cfg(windows)]
-mod sysrand_chunk {
-    use crate::{error, polyfill};
-
-    #[inline]
-    pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        use winapi::shared::wtypesbase::ULONG;
-
-        assert!(size_of::<usize>() >= size_of::<ULONG>());
-        let len = core::cmp::min(dest.len(), polyfill::usize_from_u32(ULONG::max_value()));
-        let result = unsafe {
-            winapi::um::ntsecapi::RtlGenRandom(
-                dest.as_mut_ptr() as *mut winapi::ctypes::c_void,
-                len as ULONG,
-            )
-        };
-        if result == 0 {
-            return Err(error::Unspecified);
-        }
-
-        Ok(len)
-    }
-}
-
-#[cfg(all(
-    any(
-        target_os = "android",
-        target_os = "linux",
-        target_arch = "wasm32",
-        windows
-    ),
-    not(feature = "getrandom")
-))]
-mod sysrand {
-    use super::sysrand_chunk::chunk;
-    use crate::error;
-
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        let mut read_len = 0;
-        while read_len < dest.len() {
-            let chunk_len = chunk(&mut dest[read_len..])?;
-            read_len += chunk_len;
-        }
-        Ok(())
-    }
-}
-
-#[cfg(all(feature = "getrandom", target_arch = "wasm32"))]
-mod getrandom {
-    use crate::error;
-
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        getrandom::fill(dest).map_err(|_| error::Unspecified)
-    }
-}
-
-// Keep the `cfg` conditions in sync with the conditions in lib.rs.
-#[cfg(all(
-    any(target_os = "android", target_os = "linux"),
-    feature = "dev_urandom_fallback"
-))]
-mod sysrand_or_urandom {
-    use crate::error;
-
-    enum Mechanism {
-        Sysrand,
-        DevURandom,
-    }
-
-    #[inline]
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        use once_cell::sync::Lazy;
-        static MECHANISM: Lazy<Mechanism> = Lazy::new(|| {
-            let mut dummy = [0u8; 1];
-            if super::sysrand_chunk::chunk(&mut dummy[..]).is_err() {
-                Mechanism::DevURandom
-            } else {
-                Mechanism::Sysrand
-            }
-        });
-
-        match *MECHANISM {
-            Mechanism::Sysrand => super::sysrand::fill(dest),
-            Mechanism::DevURandom => super::urandom::fill(dest),
-        }
-    }
-}
-
-#[cfg(any(
-    all(
-        any(target_os = "android", target_os = "linux"),
-        feature = "dev_urandom_fallback"
-    ),
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-    target_os = "illumos"
-))]
-mod urandom {
-    use crate::error;
-
-    #[cfg_attr(any(target_os = "android", target_os = "linux"), cold, inline(never))]
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        extern crate std;
-
-        use once_cell::sync::Lazy;
-
-        static FILE: Lazy<Result<std::fs::File, std::io::Error>> =
-            Lazy::new(|| std::fs::File::open("/dev/urandom"));
-
-        match *FILE {
-            Ok(ref file) => {
-                use std::io::Read;
-                (&*file).read_exact(dest).map_err(|_| error::Unspecified)
-            }
-            Err(_) => Err(error::Unspecified),
-        }
-    }
-}
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-mod darwin {
-    use crate::{c, error};
-
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        let r = unsafe { SecRandomCopyBytes(kSecRandomDefault, dest.len(), dest.as_mut_ptr()) };
-        match r {
-            0 => Ok(()),
-            _ => Err(error::Unspecified),
-        }
-    }
-
-    // XXX: This is emulating an opaque type with a non-opaque type. TODO: Fix
-    // this when
-    // https://github.com/rust-lang/rfcs/pull/1861#issuecomment-274613536 is
-    // resolved.
-    #[repr(C)]
-    struct SecRandomRef([u8; 0]);
-
-    #[link(name = "Security", kind = "framework")]
-    extern "C" {
-        static kSecRandomDefault: &'static SecRandomRef;
-
-        // For now `rnd` must be `kSecRandomDefault`.
-        #[must_use]
-        fn SecRandomCopyBytes(
-            rnd: &'static SecRandomRef,
-            count: c::size_t,
-            bytes: *mut u8,
-        ) -> c::int;
-    }
-}
-
-#[cfg(any(target_os = "fuchsia"))]
-mod fuchsia {
-    use crate::error;
-
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        unsafe {
-            zx_cprng_draw(dest.as_mut_ptr(), dest.len());
-        }
-        Ok(())
-    }
-
-    #[link(name = "zircon")]
-    extern "C" {
-        fn zx_cprng_draw(buffer: *mut u8, length: usize);
+    fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
+        getrandom::getrandom(dest).map_err(|_| error::Unspecified)
     }
 }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -233,6 +233,7 @@ mod sysrand_chunk {
     target_vendor = "unknown",
     target_os = "unknown",
     target_env = "",
+    not(feature = "andi"),
 ))]
 mod sysrand_chunk {
     use crate::error;
@@ -269,12 +270,7 @@ mod sysrand_chunk {
     }
 }
 
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "wasi",
-    target_env = "p1",
-))]
+#[cfg(feature = "andi")]
 mod sysrand_chunk {
     use crate::error;
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -233,12 +233,12 @@ mod sysrand_chunk {
     target_vendor = "unknown",
     target_os = "unknown",
     target_env = "",
-    not(feature = "andi"),
+    not(feature = "custom_rand"),
 ))]
 mod sysrand_chunk {
     use crate::error;
     use js_sys::Reflect;
-    use wasm_bindgen::{JsValue, JsCast};
+    use wasm_bindgen::{JsCast, JsValue};
     use web_sys::Crypto;
 
     /**
@@ -249,7 +249,8 @@ mod sysrand_chunk {
     fn get_crypto() -> Result<Crypto, error::Unspecified> {
         Reflect::get(&js_sys::global(), &JsValue::from("crypto"))
             .map_err(|_| error::Unspecified)?
-            .dyn_into::<Crypto>().map_err(|_| error::Unspecified)
+            .dyn_into::<Crypto>()
+            .map_err(|_| error::Unspecified)
     }
 
     pub fn chunk(mut dest: &mut [u8]) -> Result<usize, error::Unspecified> {
@@ -270,13 +271,42 @@ mod sysrand_chunk {
     }
 }
 
-#[cfg(feature = "andi")]
+/// Macro to register a custom random fill function. Similar to the in op-random.
+#[cfg(feature = "custom_rand")]
+#[macro_export]
+macro_rules! register_custom_random_fill {
+    ($path:path) => {
+        const _: () = {
+            #[unsafe(no_mangle)]
+            unsafe extern "Rust" fn __op_custom_random_fill(dest: &mut [u8]) -> u32 {
+                // Make sure the passed function has the type we expect
+                type F = fn(&mut [u8]) -> ::core::result::Result<(), ()>;
+                let f: F = $path;
+                match f(dest) {
+                    Ok(()) => 0,
+                    Err(()) => 1,
+                }
+            }
+        };
+    };
+}
+#[cfg(feature = "custom_rand")]
 mod sysrand_chunk {
     use crate::error;
 
     pub fn chunk(mut dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        // The getrandom crate is used in the latest version of ring, and has WASI P1 support: https://github.com/briansmith/ring/blob/522afb658067bed0512a49f66bd4c07389b51ab3/src/rand.rs#L168
-        getrandom::getrandom(dest).map_err(|_| error::Unspecified)
+        unsafe extern "Rust" {
+            fn __op_custom_random_fill(dest: &mut [u8]) -> u32;
+        }
+
+        // SAFETY: This call is safe as long as the custom implementation supplied to the
+        // macro above is safe and controlled by us. The `__op_` prefix helps in preventing
+        // other crates from injecting a different random fill implementation.
+        let ret = unsafe { __op_custom_random_fill(dest) };
+        match ret {
+            0 => Ok(dest.len()),
+            _ => Err(error::Unspecified),
+        }
     }
 }
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -163,13 +163,18 @@ impl sealed::SecureRandom for SystemRandom {
 
 impl crate::sealed::Sealed for SystemRandom {}
 
-#[cfg(any(
-    all(
-        any(target_os = "android", target_os = "linux"),
-        not(feature = "dev_urandom_fallback")
+#[cfg(all(feature = "getrandom", target_arch = "wasm32"))]
+use self::getrandom::fill as fill_impl;
+#[cfg(all(
+    any(
+        all(
+            any(target_os = "android", target_os = "linux"),
+            not(feature = "dev_urandom_fallback")
+        ),
+        target_arch = "wasm32",
+        windows
     ),
-    target_arch = "wasm32",
-    windows
+    not(feature = "getrandom")
 ))]
 use self::sysrand::fill as fill_impl;
 
@@ -233,7 +238,6 @@ mod sysrand_chunk {
     target_vendor = "unknown",
     target_os = "unknown",
     target_env = "",
-    not(feature = "custom_rand"),
 ))]
 mod sysrand_chunk {
     use crate::error;
@@ -271,45 +275,6 @@ mod sysrand_chunk {
     }
 }
 
-/// Macro to register a custom random fill function. Similar to the in op-random.
-#[cfg(feature = "custom_rand")]
-#[macro_export]
-macro_rules! register_custom_random_fill {
-    ($path:path) => {
-        const _: () = {
-            #[unsafe(no_mangle)]
-            unsafe extern "Rust" fn __op_custom_random_fill(dest: &mut [u8]) -> u32 {
-                // Make sure the passed function has the type we expect
-                type F = fn(&mut [u8]) -> ::core::result::Result<(), ()>;
-                let f: F = $path;
-                match f(dest) {
-                    Ok(()) => 0,
-                    Err(()) => 1,
-                }
-            }
-        };
-    };
-}
-#[cfg(feature = "custom_rand")]
-mod sysrand_chunk {
-    use crate::error;
-
-    pub fn chunk(mut dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        unsafe extern "Rust" {
-            fn __op_custom_random_fill(dest: &mut [u8]) -> u32;
-        }
-
-        // SAFETY: This call is safe as long as the custom implementation supplied to the
-        // macro above is safe and controlled by us. The `__op_` prefix helps in preventing
-        // other crates from injecting a different random fill implementation.
-        let ret = unsafe { __op_custom_random_fill(dest) };
-        match ret {
-            0 => Ok(dest.len()),
-            _ => Err(error::Unspecified),
-        }
-    }
-}
-
 #[cfg(windows)]
 mod sysrand_chunk {
     use crate::{error, polyfill};
@@ -334,11 +299,14 @@ mod sysrand_chunk {
     }
 }
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_arch = "wasm32",
-    windows
+#[cfg(all(
+    any(
+        target_os = "android",
+        target_os = "linux",
+        target_arch = "wasm32",
+        windows
+    ),
+    not(feature = "getrandom")
 ))]
 mod sysrand {
     use super::sysrand_chunk::chunk;
@@ -351,6 +319,15 @@ mod sysrand {
             read_len += chunk_len;
         }
         Ok(())
+    }
+}
+
+#[cfg(all(feature = "getrandom", target_arch = "wasm32"))]
+mod getrandom {
+    use crate::error;
+
+    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
+        getrandom::fill(dest).map_err(|_| error::Unspecified)
     }
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -280,15 +280,8 @@ pub use crate::ec::{
 pub use crate::rsa::{
     keypair::signing::{RsaKeyPair, RsaSubjectPublicKey},
     padding::{
-        RsaEncoding,
-
-        RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY,
-        RSA_PKCS1_SHA256,
-        RSA_PKCS1_SHA384,
-        RSA_PKCS1_SHA512,
-        RSA_PSS_SHA256,
-        RSA_PSS_SHA384,
-        RSA_PSS_SHA512,
+        RsaEncoding, RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY, RSA_PKCS1_SHA256, RSA_PKCS1_SHA384,
+        RSA_PKCS1_SHA512, RSA_PSS_SHA256, RSA_PSS_SHA384, RSA_PSS_SHA512,
     },
     verification::{
         RsaPublicKeyComponents, RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,

--- a/src/test.rs
+++ b/src/test.rs
@@ -486,7 +486,7 @@ pub mod rand {
     }
 
     impl rand::sealed::SecureRandom for FixedByteRandom {
-        fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
+        fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
             polyfill::slice::fill(dest, self.byte);
             Ok(())
         }
@@ -501,7 +501,7 @@ pub mod rand {
     }
 
     impl rand::sealed::SecureRandom for FixedSliceRandom<'_> {
-        fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
+        fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
             dest.copy_from_slice(self.bytes);
             Ok(())
         }
@@ -524,7 +524,7 @@ pub mod rand {
     }
 
     impl rand::sealed::SecureRandom for FixedSliceSequenceRandom<'_> {
-        fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
+        fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
             let current = unsafe { *self.current.get() };
             let bytes = self.bytes[current];
             dest.copy_from_slice(bytes);


### PR DESCRIPTION
### Reason to be

When performing RSA OAEP encryption in the Go SDK (WASM running in a Go WASM runtime), the operation would fail denoting failing to perform random filling:

```
        op_extism_core.wasm._ZN6js_sys6global17get_global_object4SELF4init17h4d673e45143d2e53E(i32)
        op_extism_core.wasm._ZN12wasm_bindgen22JsThreadLocal$LT$T$GT$4with17h8b0f9f18cea8e49cE(i32,i32)
        op_extism_core.wasm._ZN6js_sys6global17get_global_object17hbfab08702720d141E() i32
        op_extism_core.wasm._ZN9once_cell6unsync17OnceCell$LT$T$GT$15get_or_try_init17ha53bb5b02ae68570E(i32,i32) i32
        op_extism_core.wasm._ZN6js_sys6global17hdd8f46673e1fd64bE() i32
        op_extism_core.wasm._ZN4ring4rand13sysrand_chunk5chunk17hbf9957f87e7f0b60E(i32,i32,i32)
        op_extism_core.wasm._ZN4ring4rand7sysrand4fill17ha1d94cfbd6ab0ae8E(i32,i32) i32
        op_extism_core.wasm._ZN46_$LT$T$u20$as$u20$ring..rand..SecureRandom$GT$4fill17h32ee64e14391b3a9E.llvm.17293774610970395294(i32,i32,i32) i32
        op_extism_core.wasm._ZN4ring3rsa7padding11oaep_encode17hab00cd16a8cb527fE(i32,i32,i32,i32,i32,i32,i32)
        op_extism_core.wasm._ZN4ring3rsa6public4oaep45_$LT$impl$u20$ring..rsa..public..key..Key$GT$28encrypt_oaep_bytes_less_safe17hf7c375bc76bbca06E(i32,i32,i32,i32,i32,i32,i32)
        op_extism_core.wasm._ZN9op_crypto3rsa12RsaPublicKey7encrypt17hd13b7e976966bcf4E(i32,i32,i32,i32)

```

This shows how ring tried to find the `crypto` global object in a JS environment like a browser, but it fails, because we are in Go.

Therefore, as a minimal change, I am back porting mainstream ring's secure random fill logic to our fork.

### Thought process

The options were to either patch up this fork like in this PR, or to move to something else that supports the host runtime for performing RSA encryption in op-crypto, but it seemed like too much work. Another option was to introduce a `custom_rand` feature on this repo and export a symbol ourselves.

However, to no stray too far away from the mainstream ring repo, we are back porting mainstream ring's [rand.rs file](https://github.com/briansmith/ring/blob/main/src/rand.rs) which makes use of  `getrandom` 0.2.10.

## Notes

All the other changes were made by my `cargo fmt`.