### PR TITLE
Next release build prep

### DIFF
--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -297,7 +297,7 @@ impl core::fmt::Debug for NonceRandom<'_> {
 }
 
 impl rand::sealed::SecureRandom for NonceRandom<'_> {
-    fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
+    fn fill_impl(&self, dest: &mut [u8], _: sealed::Arg) -> Result<(), error::Unspecified> {
         // Use the same digest algorithm that will be used to digest the
         // message. The digest algorithm's output is exactly the right size;
         // this is checked below.


### PR DESCRIPTION
This PR follows up on #14 to fix some problems I encountered going through the build and packaging process. There are a few lint warnings that aren't meaningful like extra parentheses but the one error stops the packaging process outright and therefore needed fixed:

<img width="1438" height="430" alt="image" src="https://github.com/user-attachments/assets/e4735b7e-e97e-42bb-ac3b-fd6a66450810" />
