### PR TITLE
Custom WASM runtime RNG support release

### DIFF
--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -406,6 +406,9 @@ path = "tests/rsa_tests.rs"
 name = "signature_tests"
 path = "tests/signature_tests.rs"
 
+[dependencies.getrandom]
+version = "0.2.10"
+
 [dependencies.untrusted]
 version = "0.7.1"
 
@@ -421,10 +424,12 @@ default = [
 ]
 dev_urandom_fallback = ["once_cell"]
 internal_benches = []
+less-safe-getrandom-custom-wasm-hostruntime = []
 slow_tests = []
 std = ["alloc"]
 test_logging = []
 wasm32_c = []
+wasm32_unknown_unknown_js = ["getrandom/js"]
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies.js-sys]
 version = "0.3.51"

--- a/ring/Cargo.toml.orig
+++ b/ring/Cargo.toml.orig
@@ -328,6 +328,7 @@ name = "ring"
 
 [dependencies]
 untrusted = { version = "0.7.1" }
+getrandom = { version = "0.2.10" }
 
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 spin = { version = "0.9.2", default-features = false, features = ["once"] }
@@ -361,11 +362,13 @@ cc = { version = "1.0.66", default-features = false }
 default = ["alloc", "dev_urandom_fallback"]
 alloc = []
 dev_urandom_fallback = ["once_cell"]
+less-safe-getrandom-custom-wasm-hostruntime = []
 internal_benches = []
 slow_tests = []
 std = ["alloc"]
 test_logging = []
 wasm32_c = []
+wasm32_unknown_unknown_js = ["getrandom/js"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/ring/src/agreement.rs
+++ b/ring/src/agreement.rs
@@ -141,6 +141,7 @@ impl EphemeralPrivateKey {
         self.algorithm
     }
 
+    /// Less safe access to the private key bytes.
     #[cfg(test)]
     pub fn bytes(&self) -> &[u8] {
         self.private_key.bytes_less_safe()

--- a/ring/src/ec/suite_b/ecdsa/signing.rs
+++ b/ring/src/ec/suite_b/ecdsa/signing.rs
@@ -297,7 +297,7 @@ impl core::fmt::Debug for NonceRandom<'_> {
 }
 
 impl rand::sealed::SecureRandom for NonceRandom<'_> {
-    fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
+    fn fill_impl(&self, dest: &mut [u8], _: sealed::Arg) -> Result<(), error::Unspecified> {
         // Use the same digest algorithm that will be used to digest the
         // message. The digest algorithm's output is exactly the right size;
         // this is checked below.

--- a/ring/src/lib.rs
+++ b/ring/src/lib.rs
@@ -125,4 +125,5 @@ mod sealed {
     // impl sealed::Sealed for MyType {}
     // ```
     pub trait Sealed {}
+    pub struct Arg;
 }

--- a/ring/src/rand.rs
+++ b/ring/src/rand.rs
@@ -4,9 +4,9 @@
 // purpose with or without fee is hereby granted, provided that the above
 // copyright notice and this permission notice appear in all copies.
 //
-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 // WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
 // SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 // WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
@@ -14,16 +14,8 @@
 
 //! Cryptographic pseudo-random number generation.
 //!
-//! An application should create a single `SystemRandom` and then use it for
-//! all randomness generation. Functions that generate random bytes should take
-//! a `&dyn SecureRandom` parameter instead of instantiating their own. Besides
-//! being more efficient, this also helps document where non-deterministic
-//! (random) outputs occur. Taking a reference to a `SecureRandom` also helps
-//! with testing techniques like fuzzing, where it is useful to use a
-//! (non-secure) deterministic implementation of `SecureRandom` so that results
-//! can be replayed. Following this pattern also may help with sandboxing
-//! (seccomp filters on Linux in particular). See `SystemRandom`'s
-//! documentation for more details.
+//! *ring* functions that generate random bytes take a `&dyn SecureRandom`
+//! parameter to make it clear which functions are non-deterministic.
 
 use crate::error;
 
@@ -39,7 +31,7 @@ where
 {
     #[inline(always)]
     fn fill(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        self.fill_impl(dest)
+        self.fill_impl(dest, crate::sealed::Arg)
     }
 }
 
@@ -61,10 +53,7 @@ impl<T: RandomlyConstructable> Random<T> {
 #[inline]
 pub fn generate<T: RandomlyConstructable>(
     rng: &dyn SecureRandom,
-) -> Result<Random<T>, error::Unspecified>
-where
-    T: RandomlyConstructable,
-{
+) -> Result<Random<T>, error::Unspecified> {
     let mut r = T::zero();
     rng.fill(r.as_mut_bytes())?;
     Ok(Random(r))
@@ -75,7 +64,11 @@ pub(crate) mod sealed {
 
     pub trait SecureRandom: core::fmt::Debug {
         /// Fills `dest` with random bytes.
-        fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified>;
+        fn fill_impl(
+            &self,
+            dest: &mut [u8],
+            _: crate::sealed::Arg,
+        ) -> Result<(), error::Unspecified>;
     }
 
     pub trait RandomlyConstructable: Sized {
@@ -83,21 +76,17 @@ pub(crate) mod sealed {
         fn as_mut_bytes(&mut self) -> &mut [u8]; // `AsMut<[u8]>::as_mut`
     }
 
-    macro_rules! impl_random_arrays {
-        [ $($len:expr)+ ] => {
-            $(
-                impl RandomlyConstructable for [u8; $len] {
-                    #[inline]
-                    fn zero() -> Self { [0; $len] }
+    impl<const N: usize> RandomlyConstructable for [u8; N] {
+        #[inline]
+        fn zero() -> Self {
+            [0; N]
+        }
 
-                    #[inline]
-                    fn as_mut_bytes(&mut self) -> &mut [u8] { &mut self[..] }
-                }
-            )+
+        #[inline]
+        fn as_mut_bytes(&mut self) -> &mut [u8] {
+            &mut self[..]
         }
     }
-
-    impl_random_arrays![4 8 16 32 48 64 128 256];
 }
 
 /// A type that can be returned by `ring::rand::generate()`.
@@ -107,6 +96,11 @@ impl<T> RandomlyConstructable for T where T: sealed::RandomlyConstructable {}
 /// A secure random number generator where the random values come directly
 /// from the operating system.
 ///
+/// "Directly from the operating system" here presently means "whatever the
+/// `getrandom` crate does" but that may change in the future. That roughly
+/// means calling libc's `getrandom` function or whatever is analogous to that;
+/// see the `getrandom` crate's documentation for more info.
+///
 /// A single `SystemRandom` may be shared across multiple threads safely.
 ///
 /// `new()` is guaranteed to always succeed and to have low latency; it won't
@@ -115,34 +109,6 @@ impl<T> RandomlyConstructable for T where T: sealed::RandomlyConstructable {}
 /// initialization is deferred to it. Therefore, it may be a good idea to call
 /// `fill()` once at a non-latency-sensitive time to minimize latency for
 /// future calls.
-///
-/// On Linux (including Android), `fill()` will use the [`getrandom`] syscall.
-/// If the kernel is too old to support `getrandom` then by default `fill()`
-/// falls back to reading from `/dev/urandom`. This decision is made the first
-/// time `fill` *succeeds*. The fallback to `/dev/urandom` can be disabled by
-/// disabling the `dev_urandom_fallback` default feature; this should be done
-/// whenever the target system is known to support `getrandom`. When
-/// `/dev/urandom` is used, a file handle for `/dev/urandom` won't be opened
-/// until `fill` is called; `SystemRandom::new()` will not open `/dev/urandom`
-/// or do other potentially-high-latency things. The file handle will never be
-/// closed, until the operating system closes it at process shutdown. All
-/// instances of `SystemRandom` will share a single file handle. To properly
-/// implement seccomp filtering when the `dev_urandom_fallback` default feature
-/// is disabled, allow `getrandom` through. When the fallback is enabled, allow
-/// file opening, `getrandom`, and `read` up until the first call to `fill()`
-/// succeeds; after that, allow `getrandom` and `read`.
-///
-/// On macOS and iOS, `fill()` is implemented using `SecRandomCopyBytes`.
-///
-/// On wasm32-unknown-unknown (non-WASI), `fill()` is implemented using
-/// `window.crypto.getRandomValues()`. It must be used in a context where the
-/// global object is a `Window`; i.e. it must not be used in a Worker or a
-/// non-browser context.
-///
-/// On Windows, `fill` is implemented using the platform's API for secure
-/// random number generation.
-///
-/// [`getrandom`]: http://man7.org/linux/man-pages/man2/getrandom.2.html
 #[derive(Clone, Debug)]
 pub struct SystemRandom(());
 
@@ -154,277 +120,50 @@ impl SystemRandom {
     }
 }
 
+// Use the `getrandom` crate whenever it is using the environment's (operating
+// system's) CSPRNG. Avoid using it on targets where it uses the `rdrand`
+// implementation.
+#[cfg(any(
+    feature = "less-safe-getrandom-custom-wasm-hostruntime",
+    target_os = "aix",
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "haiku",
+    target_os = "hermit",
+    target_os = "hurd",
+    target_os = "horizon",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "vita",
+    target_os = "windows",
+    target_os = "nto",
+    all(
+        target_vendor = "apple",
+        any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "visionos",
+            target_os = "watchos",
+        )
+    ),
+    all(
+        target_arch = "wasm32",
+        any(
+            target_os = "wasi",
+            all(target_os = "unknown", feature = "wasm32_unknown_unknown_js")
+        )
+    ),
+))]
 impl sealed::SecureRandom for SystemRandom {
     #[inline(always)]
-    fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        fill_impl(dest)
-    }
-}
-
-impl crate::sealed::Sealed for SystemRandom {}
-
-#[cfg(any(
-    all(
-        any(target_os = "android", target_os = "linux"),
-        not(feature = "dev_urandom_fallback")
-    ),
-    target_arch = "wasm32",
-    windows
-))]
-use self::sysrand::fill as fill_impl;
-
-#[cfg(all(
-    any(target_os = "android", target_os = "linux"),
-    feature = "dev_urandom_fallback"
-))]
-use self::sysrand_or_urandom::fill as fill_impl;
-
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-))]
-use self::urandom::fill as fill_impl;
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-use self::darwin::fill as fill_impl;
-
-#[cfg(any(target_os = "fuchsia"))]
-use self::fuchsia::fill as fill_impl;
-
-#[cfg(any(target_os = "android", target_os = "linux"))]
-mod sysrand_chunk {
-    use crate::{c, error};
-
-    #[inline]
-    pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        let chunk_len: c::size_t = dest.len();
-        let r = unsafe { libc::syscall(libc::SYS_getrandom, dest.as_mut_ptr(), chunk_len, 0) };
-        if r < 0 {
-            let errno;
-
-            #[cfg(target_os = "linux")]
-            {
-                errno = unsafe { *libc::__errno_location() };
-            }
-
-            #[cfg(target_os = "android")]
-            {
-                errno = unsafe { *libc::__errno() };
-            }
-
-            if errno == libc::EINTR {
-                // If an interrupt occurs while getrandom() is blocking to wait
-                // for the entropy pool, then EINTR is returned. Returning 0
-                // will cause the caller to try again.
-                return Ok(0);
-            }
-            return Err(error::Unspecified);
-        }
-        Ok(r as usize)
-    }
-}
-
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown",
-    target_env = "",
-))]
-mod sysrand_chunk {
-    use crate::error;
-    use js_sys::Reflect;
-    use wasm_bindgen::{JsValue, JsCast};
-    use web_sys::Crypto;
-
-    /**
-     * Gets a handle to Crypto in both normal and worker environments. Based on
-     * the discussion in https://github.com/rustwasm/wasm-bindgen/issues/2148
-     * and the approach taken here: https://github.com/devashishdxt/rexie/commit/8637e4ebc2d2dfc6b33cd60dc85b99e46d6afa96
-     */
-    fn get_crypto() -> Result<Crypto, error::Unspecified> {
-        Reflect::get(&js_sys::global(), &JsValue::from("crypto"))
-            .map_err(|_| error::Unspecified)?
-            .dyn_into::<Crypto>().map_err(|_| error::Unspecified)
-    }
-
-    pub fn chunk(mut dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        // This limit is specified in
-        // https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues.
-        const MAX_LEN: usize = 65_536;
-        if dest.len() > MAX_LEN {
-            dest = &mut dest[..MAX_LEN];
-        };
-
-        let crypto = get_crypto()?;
-
-        let _ = crypto
-            .get_random_values_with_u8_array(dest)
-            .map_err(|_| error::Unspecified)?;
-
-        Ok(dest.len())
-    }
-}
-
-#[cfg(windows)]
-mod sysrand_chunk {
-    use crate::{error, polyfill};
-
-    #[inline]
-    pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        use winapi::shared::wtypesbase::ULONG;
-
-        assert!(size_of::<usize>() >= size_of::<ULONG>());
-        let len = core::cmp::min(dest.len(), polyfill::usize_from_u32(ULONG::max_value()));
-        let result = unsafe {
-            winapi::um::ntsecapi::RtlGenRandom(
-                dest.as_mut_ptr() as *mut winapi::ctypes::c_void,
-                len as ULONG,
-            )
-        };
-        if result == 0 {
-            return Err(error::Unspecified);
-        }
-
-        Ok(len)
-    }
-}
-
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_arch = "wasm32",
-    windows
-))]
-mod sysrand {
-    use super::sysrand_chunk::chunk;
-    use crate::error;
-
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        let mut read_len = 0;
-        while read_len < dest.len() {
-            let chunk_len = chunk(&mut dest[read_len..])?;
-            read_len += chunk_len;
-        }
-        Ok(())
-    }
-}
-
-// Keep the `cfg` conditions in sync with the conditions in lib.rs.
-#[cfg(all(
-    any(target_os = "android", target_os = "linux"),
-    feature = "dev_urandom_fallback"
-))]
-mod sysrand_or_urandom {
-    use crate::error;
-
-    enum Mechanism {
-        Sysrand,
-        DevURandom,
-    }
-
-    #[inline]
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        use once_cell::sync::Lazy;
-        static MECHANISM: Lazy<Mechanism> = Lazy::new(|| {
-            let mut dummy = [0u8; 1];
-            if super::sysrand_chunk::chunk(&mut dummy[..]).is_err() {
-                Mechanism::DevURandom
-            } else {
-                Mechanism::Sysrand
-            }
-        });
-
-        match *MECHANISM {
-            Mechanism::Sysrand => super::sysrand::fill(dest),
-            Mechanism::DevURandom => super::urandom::fill(dest),
-        }
-    }
-}
-
-#[cfg(any(
-    all(
-        any(target_os = "android", target_os = "linux"),
-        feature = "dev_urandom_fallback"
-    ),
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "solaris",
-    target_os = "illumos"
-))]
-mod urandom {
-    use crate::error;
-
-    #[cfg_attr(any(target_os = "android", target_os = "linux"), cold, inline(never))]
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        extern crate std;
-
-        use once_cell::sync::Lazy;
-
-        static FILE: Lazy<Result<std::fs::File, std::io::Error>> =
-            Lazy::new(|| std::fs::File::open("/dev/urandom"));
-
-        match *FILE {
-            Ok(ref file) => {
-                use std::io::Read;
-                (&*file).read_exact(dest).map_err(|_| error::Unspecified)
-            }
-            Err(_) => Err(error::Unspecified),
-        }
-    }
-}
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-mod darwin {
-    use crate::{c, error};
-
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        let r = unsafe { SecRandomCopyBytes(kSecRandomDefault, dest.len(), dest.as_mut_ptr()) };
-        match r {
-            0 => Ok(()),
-            _ => Err(error::Unspecified),
-        }
-    }
-
-    // XXX: This is emulating an opaque type with a non-opaque type. TODO: Fix
-    // this when
-    // https://github.com/rust-lang/rfcs/pull/1861#issuecomment-274613536 is
-    // resolved.
-    #[repr(C)]
-    struct SecRandomRef([u8; 0]);
-
-    #[link(name = "Security", kind = "framework")]
-    extern "C" {
-        static kSecRandomDefault: &'static SecRandomRef;
-
-        // For now `rnd` must be `kSecRandomDefault`.
-        #[must_use]
-        fn SecRandomCopyBytes(
-            rnd: &'static SecRandomRef,
-            count: c::size_t,
-            bytes: *mut u8,
-        ) -> c::int;
-    }
-}
-
-#[cfg(any(target_os = "fuchsia"))]
-mod fuchsia {
-    use crate::error;
-
-    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        unsafe {
-            zx_cprng_draw(dest.as_mut_ptr(), dest.len());
-        }
-        Ok(())
-    }
-
-    #[link(name = "zircon")]
-    extern "C" {
-        fn zx_cprng_draw(buffer: *mut u8, length: usize);
+    fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
+        getrandom::getrandom(dest).map_err(|_| error::Unspecified)
     }
 }

--- a/ring/src/signature.rs
+++ b/ring/src/signature.rs
@@ -280,15 +280,8 @@ pub use crate::ec::{
 pub use crate::rsa::{
     keypair::signing::{RsaKeyPair, RsaSubjectPublicKey},
     padding::{
-        RsaEncoding,
-
-        RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY,
-        RSA_PKCS1_SHA256,
-        RSA_PKCS1_SHA384,
-        RSA_PKCS1_SHA512,
-        RSA_PSS_SHA256,
-        RSA_PSS_SHA384,
-        RSA_PSS_SHA512,
+        RsaEncoding, RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY, RSA_PKCS1_SHA256, RSA_PKCS1_SHA384,
+        RSA_PKCS1_SHA512, RSA_PSS_SHA256, RSA_PSS_SHA384, RSA_PSS_SHA512,
     },
     verification::{
         RsaPublicKeyComponents, RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,

--- a/ring/src/test.rs
+++ b/ring/src/test.rs
@@ -486,7 +486,7 @@ pub mod rand {
     }
 
     impl rand::sealed::SecureRandom for FixedByteRandom {
-        fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
+        fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
             polyfill::slice::fill(dest, self.byte);
             Ok(())
         }
@@ -501,7 +501,7 @@ pub mod rand {
     }
 
     impl rand::sealed::SecureRandom for FixedSliceRandom<'_> {
-        fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
+        fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
             dest.copy_from_slice(self.bytes);
             Ok(())
         }
@@ -524,7 +524,7 @@ pub mod rand {
     }
 
     impl rand::sealed::SecureRandom for FixedSliceSequenceRandom<'_> {
-        fn fill_impl(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
+        fn fill_impl(&self, dest: &mut [u8], _: crate::sealed::Arg) -> Result<(), error::Unspecified> {
             let current = unsafe { *self.current.get() };
             let bytes = self.bytes[current];
             dest.copy_from_slice(bytes);


### PR DESCRIPTION
This is a rebase of #14 and #15 with the packaged release changes. For this release, there were no pregenerated object files changes in the end as the above PRs only modified pure Rust source and nothing around the FFI. I manually checked both the `git diff` against the non-release branch and the local object file changes to confirm they only had one timestamp change like we expect (and the automated tooling in `tools/` confirms as well):

<img width="586" height="109" alt="ring_release_after_cherrypicks" src="https://github.com/user-attachments/assets/f608f80f-14dc-4139-b045-967cbbb5a971" />

<img width="1348" height="125" alt="ring_release_asm_changes" src="https://github.com/user-attachments/assets/4d02fb40-80ba-4448-ad6a-82690a10d125" />

After this merges, we can create a [new Git tag](https://github.com/1Password/ring/tree/1p/release-0.9999?tab=readme-ov-file#tag) of `0.9999.1-1p-fork`.  I intentionally chose to not bump the tag in the `Cargo.toml` for this for two reasons:
- We would like to get this out quicker and changing it would have introduced a ton of noise into the pre-generated object files to review.
- We depend on these Git tags via both a tag name and Git hash. As long as those change, the cargo version itself doesn't have much value because 1Password are the only consumers and don't need to worry about semver.
